### PR TITLE
Repair a bug ( DecodeBuffer Interface function error )

### DIFF
--- a/src/dbr.c
+++ b/src/dbr.c
@@ -367,11 +367,11 @@ decodeBuffer(PyObject *obj, PyObject *args)
     {
         format = IPF_GRAYSCALED;
     }
-    else if (width == stride * 3)
+    else if (width == stride / 3)
     {
         format = IPF_RGB_888;
     }
-    else if (width == stride * 4)
+    else if (width == stride / 4)
     {
         format = IPF_ARGB_8888;
     }


### PR DESCRIPTION
If you use imread(<imageName>, IMREAD-UNCHANGED) which is in OpenCV-python,  the DecodeBuffer can't decode barcode.
Because the package for this function is error, this function can't transfer correct parameters to the C function.